### PR TITLE
Add README about restart command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,8 @@ $ mkdir -p config/etc
 $ cd config/etc
 $ scp isucon4:/etc/my.cnf .
 ```
+
+## Service Restart Command
+```
+ $ sudo supervisorctl restart isucon_ruby
+```


### PR DESCRIPTION
手でrubyを起動するとsupervisorで起動しているProcessと一緒に動いてしまうため、
supervisor側で再起動したい
